### PR TITLE
Create test pipeline

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -1,0 +1,17 @@
+name: Build and test
+on:
+  push
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.test
+          tags: mindstertv:test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,27 @@
+# Define the base image
+FROM node:18.14.0-alpine
+
+# Create a working directory
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files
+COPY package*.json ./
+
+# Install the dependencies
+RUN npm ci \
+ && chown -R $(id -u):$(id -g) node_modules # workaround for https://github.com/npm/cli/issues/5900
+
+# Copy the rest of the project files
+COPY . .
+
+# Run tests
+RUN npm run test
+
+# Build the Next.js application
+RUN npm run build
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "start"]


### PR DESCRIPTION
The pipeline will build next to ensure the build is valid. Furthermore it will run tests with
coverage to see that all pass and coverage is above the threshold set in jest.config.mjs

I decided  to rename the `coverage` command to `test:coverage` to emphasize that it is also running tests when used in the pipeline script