### PR TITLE
chore: setup azure ftps deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+on: push
+name: 🚀 Deploy website on push
+jobs:
+  web-deploy:
+    name: 🎉 Deploy
+    runs-on: ubuntu-latest
+    steps:
+    - name: 🚚 Get latest code
+      uses: actions/checkout@v3
+
+    - name: Use Node.js 18
+      uses: actions/setup-node@v2
+      with:
+        node-version: '18'
+      
+    - name: 🔨 Build Project
+      run: |
+        npm install
+        npm run build
+    
+    - name: 📂 Sync files
+      uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+      with:
+        server: ${{ vars.AZURE_FTPS_URL }}
+        username: ${{ vars.AZURE_FTPS_USERNAME }}
+        password: ${{ secrets.AZURE_FTPS_PASSWORD }}
+        protocol: ftps


### PR DESCRIPTION
Ftps was the easiest alternative as connecting azure to github required organization access.

fix #0008