### PR TITLE
feat: add meal description to lunch module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "postcss": "8.4.28",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
+                "react-error-boundary": "^4.0.11",
                 "tailwindcss": "3.3.3",
                 "typescript": "5.1.6"
             },
@@ -23365,6 +23366,17 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
             "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
             "dev": true
+        },
+        "node_modules/react-error-boundary": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+            "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "peerDependencies": {
+                "react": ">=16.13.1"
+            }
         },
         "node_modules/react-inspector": {
             "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "postcss": "8.4.28",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-error-boundary": "^4.0.11",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6"
     },

--- a/src/modules/lunch/__testhelpers__/model-builders.ts
+++ b/src/modules/lunch/__testhelpers__/model-builders.ts
@@ -1,0 +1,49 @@
+import { MenuItem, Order } from "@/modules/lunch/api-client/types";
+import { formatDate } from "@/commons/helpers/datetime/datetime";
+
+export const getUniqueName = () => {
+    return {
+        firstName: `John ${Math.random()}`,
+        lastName: `Doe ${Math.random()}`,
+    };
+};
+export const createOrder = (
+    mealType: string,
+    orderStatus?: Order["orderStatus"],
+    diet?: string,
+): Order => {
+    const { firstName, lastName } = getUniqueName();
+
+    return {
+        allergies: [],
+        diet: diet ?? "Vanlig",
+        firstName,
+        lastName,
+        mealType: mealType,
+        orderDate: formatDate(new Date()),
+        orderStatus: orderStatus ?? "PROCURED",
+    };
+};
+
+export const createMenuItem = (
+    mealType: string,
+    diet: string,
+    date: string = formatDate(new Date()),
+    description: string = "description",
+    allergens: string[] = [],
+): MenuItem => {
+    return {
+        id: 1,
+        diet: {
+            id: 1,
+            name: diet,
+        },
+        mealType: {
+            id: 1,
+            name: mealType,
+        },
+        description,
+        date,
+        allergens: allergens.map((a) => ({ id: 1, type: a })),
+    };
+};

--- a/src/modules/lunch/api-client/api-client.spec.ts
+++ b/src/modules/lunch/api-client/api-client.spec.ts
@@ -1,10 +1,11 @@
-import { fetchOrders } from "@/modules/lunch/api-client/api-client";
+import { fetchMenu, fetchOrders } from "@/modules/lunch/api-client/api-client";
 import jestFetchMock from "jest-fetch-mock";
 import { formatDate } from "@/commons/helpers/datetime/datetime";
+import { MenuItem } from "@/modules/lunch/api-client/types";
 
 jestFetchMock.enableMocks();
 
-describe("LunchModule: ApiClient", () => {
+describe("LunchModule: fetchOrders", () => {
     it("should fetch orders given date", async () => {
         // given
         const date = new Date();
@@ -79,5 +80,88 @@ describe("LunchModule: ApiClient", () => {
 
         // when & then
         await expect(fetchOrders(date)).rejects.toThrow();
+    });
+});
+
+describe("LunchModule: fetchMenu", () => {
+    it("should fetch menu given date", async () => {
+        // given
+        const date = new Date();
+        const menu: MenuItem[] = [
+            {
+                id: 1,
+                description: "Pasta",
+                diet: {
+                    id: 1,
+                    name: "Vanlig",
+                },
+                mealType: {
+                    id: 1,
+                    name: "Varmt",
+                },
+                date: formatDate(date),
+                allergens: [],
+            },
+        ];
+
+        fetchMock.mockOnceIf(
+            `${
+                process.env.NEXT_PUBLIC_OFFICEMINDSTER_API_ORIGIN
+            }/api/v1/public/menu/${formatDate(date)}`,
+            async () => {
+                return {
+                    body: JSON.stringify(menu),
+                    status: 200,
+                };
+            },
+        );
+
+        // when
+        const fetchedMenu = await fetchMenu(date);
+
+        // then
+        expect(fetchedMenu).toEqual(menu);
+    });
+
+    it("should fail to fetch menu when invalid json", async () => {
+        // given
+        const date = new Date();
+
+        fetchMock.mockOnceIf(
+            `${
+                process.env.NEXT_PUBLIC_OFFICEMINDSTER_API_ORIGIN
+            }/api/v1/public/menu/${formatDate(date)}`,
+            async () => {
+                return {
+                    body: "not valid json",
+                    status: 200,
+                };
+            },
+        );
+
+        // when & then
+        await expect(fetchMenu(date)).rejects.toThrow();
+    });
+
+    it("should fail to fetch order when response is not 200", async () => {
+        // given
+        const date = new Date();
+
+        fetchMock.mockOnceIf(
+            `${
+                process.env.NEXT_PUBLIC_OFFICEMINDSTER_API_ORIGIN
+            }/api/v1/public/menu/${formatDate(date)}`,
+            async () => {
+                return {
+                    body: JSON.stringify({
+                        error: "Internal server error",
+                    }),
+                    status: 500,
+                };
+            },
+        );
+
+        // when & then
+        await expect(fetchMenu(date)).rejects.toThrow();
     });
 });

--- a/src/modules/lunch/api-client/api-client.ts
+++ b/src/modules/lunch/api-client/api-client.ts
@@ -1,14 +1,5 @@
 import { formatDate } from "@/commons/helpers/datetime/datetime";
-
-export type Order = {
-    allergies: string[];
-    diet: string;
-    firstName: string;
-    lastName: string;
-    mealType: string;
-    orderDate: string;
-    orderStatus: "PROCURED" | "PENDING" | "REJECTED";
-};
+import { Order } from "@/modules/lunch/api-client/types";
 
 export const fetchOrders = async (date: Date): Promise<Order[]> => {
     const localDate = formatDate(date);
@@ -20,6 +11,22 @@ export const fetchOrders = async (date: Date): Promise<Order[]> => {
     if (!response.ok) {
         throw new Error(
             `Failed to fetch orders for date ${localDate}. Status: ${response.status}`,
+        );
+    }
+
+    return response.json();
+};
+
+export const fetchMenu = async (date: Date) => {
+    const localDate = formatDate(date);
+
+    const response = await fetch(
+        `${process.env.NEXT_PUBLIC_OFFICEMINDSTER_API_ORIGIN}/api/v1/public/menu/${localDate}`,
+    );
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch menus for date ${localDate}. Status: ${response.status}`,
         );
     }
 

--- a/src/modules/lunch/api-client/types.d.ts
+++ b/src/modules/lunch/api-client/types.d.ts
@@ -1,0 +1,33 @@
+export type Order = {
+    allergies: string[];
+    diet: string;
+    firstName: string;
+    lastName: string;
+    mealType: string;
+    orderDate: string;
+    orderStatus: "PROCURED" | "PENDING" | "REJECTED";
+};
+
+export type Diet = {
+    id: number;
+    name: string;
+};
+
+export type MealType = {
+    id: number;
+    name: string;
+};
+
+export type Allergy = {
+    id: number;
+    type: string;
+};
+
+export type MenuItem = {
+    id: number;
+    description: string;
+    diet: Diet;
+    mealType: MealType;
+    date: string;
+    allergens: Allergy[];
+};

--- a/src/modules/lunch/lunch-module.spec.tsx
+++ b/src/modules/lunch/lunch-module.spec.tsx
@@ -1,26 +1,55 @@
 import { useLunchModule } from "@/modules/lunch/lunch-module.hook";
 import { render } from "@testing-library/react";
 import LunchModuleLayout from "@/modules/lunch/lunch-module.layout";
-import { Order } from "@/modules/lunch/api-client/api-client";
-import { formatDate } from "@/commons/helpers/datetime/datetime";
 import "@testing-library/jest-dom";
+import Meal from "@/modules/lunch/meal/meal";
+import {
+    createMenuItem,
+    createOrder,
+} from "@/modules/lunch/__testhelpers__/model-builders";
 
 jest.mock("./lunch-module.hook");
 const mockedUseLunchModule = useLunchModule as jest.MockedFunction<
     typeof useLunchModule
 >;
 
+jest.mock("./meal/meal");
+const mockedMeal = Meal as jest.MockedFunction<typeof Meal>;
+
 describe("LunchModule", () => {
     it("should render all meal options available", () => {
         // given
         mockedUseLunchModule.mockReturnValue({
             meals: {
-                Varmt: [],
-                Salat: [],
-                Suppe: [],
-                Pai: [],
+                Varmt: [
+                    {
+                        menuItem: createMenuItem("Varmt", "Vanlig"),
+                        orders: [createOrder("Varmt")],
+                    },
+                ],
+                Salat: [
+                    {
+                        menuItem: createMenuItem("Salat", "Vanlig"),
+                        orders: [createOrder("Salat")],
+                    },
+                ],
+                Suppe: [
+                    {
+                        menuItem: createMenuItem("Suppe", "Vanlig"),
+                        orders: [createOrder("Suppe")],
+                    },
+                ],
+                Pai: [
+                    {
+                        menuItem: createMenuItem("Pai", "Vanlig"),
+                        orders: [createOrder("Pai")],
+                    },
+                ],
             },
+            hasOrders: true,
         });
+
+        mockedMeal.mockImplementation(({ mealType }) => <div>{mealType}</div>);
 
         // when
         const { getByText } = render(<LunchModuleLayout />);
@@ -32,47 +61,37 @@ describe("LunchModule", () => {
         expect(getByText("Pai")).toBeInTheDocument();
     });
 
-    it("should show name of persons that has placed an order", () => {
+    it("should render title", () => {
         // given
-        const order = createOrder("Varmt");
-
         mockedUseLunchModule.mockReturnValue({
-            meals: {
-                Varmt: [order],
-            },
+            meals: {},
+            hasOrders: false,
         });
 
         // when
         const { getByText } = render(<LunchModuleLayout />);
 
         // then
-        expect(getByText(order.firstName)).toBeInTheDocument();
+        expect(getByText("Dagens Lunsj")).toBeInTheDocument();
+    });
+
+    it("should render message when no orders", () => {
+        // given
+        mockedUseLunchModule.mockReturnValue({
+            meals: {},
+            hasOrders: false,
+        });
+
+        // when
+        const { getByText } = render(<LunchModuleLayout />);
+
+        // then
+        expect(
+            getByText(
+                "Ingen bestillinger i dag. Husk å bestille til i morgen!",
+            ),
+        ).toBeInTheDocument();
     });
 });
-
-const getUniqueName = () => {
-    return {
-        firstName: `John ${Math.random()}`,
-        lastName: `Doe ${Math.random()}`,
-    };
-};
-
-const createOrder = (
-    mealType: string,
-    orderStatus?: Order["orderStatus"],
-    diet?: string,
-): Order => {
-    const { firstName, lastName } = getUniqueName();
-
-    return {
-        allergies: [],
-        diet: diet ?? "Vanlig",
-        firstName,
-        lastName,
-        mealType: mealType,
-        orderDate: formatDate(new Date()),
-        orderStatus: orderStatus ?? "PROCURED",
-    };
-};
 
 export {};

--- a/src/modules/lunch/lunch-module.tsx
+++ b/src/modules/lunch/lunch-module.tsx
@@ -1,45 +1,29 @@
 import { useLunchModule } from "@/modules/lunch/lunch-module.hook";
-import { Chip } from "@nextui-org/chip";
-import { Order } from "@/modules/lunch/api-client/api-client";
+import React from "react";
+import Meal from "@/modules/lunch/meal/meal";
 
 const LunchModule = () => {
-    const { meals } = useLunchModule();
+    const { meals, hasOrders } = useLunchModule();
 
     return (
-        <div className="flex h-full flex-col gap-9 bg-black p-8 font-sans @container">
+        <div className="flex h-full flex-col gap-7 bg-black p-8 font-sans @container">
             <h1 className="mb-2 text-xl font-semibold tracking-wide @xs:text-2xl @sm:text-3xl">
                 Dagens Lunsj
             </h1>
-            <div className="grid grid-cols-1 gap-y-7 @xl:grid-cols-3">
-                {Object.entries(meals).map(([mealType, orders]) => (
-                    <Meal key={mealType} mealType={mealType} orders={orders} />
-                ))}
-            </div>
+            {hasOrders ? (
+                <div className="grid grid-cols-1 gap-x-2 gap-y-5 @lg:grid-cols-3 @lg:grid-rows-2">
+                    {Object.entries(meals).map(([mealType, mealVariants]) => (
+                        <Meal
+                            key={mealType}
+                            mealType={mealType}
+                            variants={mealVariants}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <p>Ingen bestillinger i dag. Husk å bestille til i morgen!</p>
+            )}
         </div>
     );
 };
-
-const Meal = ({
-    mealType,
-    orders,
-}: {
-    mealType: Order["mealType"];
-    orders: Order[];
-}) => {
-    return (
-        <div className="flex flex-col gap-y-2 @xl:gap-y-4">
-            <h2 className="font-serif text-lg">{mealType}</h2>
-            <ul className="flex flex-wrap gap-2">
-                {orders.map((order) => (
-                    <li key={order.firstName}>
-                        <Chip variant="shadow" size="sm" color="secondary">
-                            {order.firstName}
-                        </Chip>
-                    </li>
-                ))}
-            </ul>
-        </div>
-    );
-};
-
 export default LunchModule;

--- a/src/modules/lunch/meal/hook/meal.hook.spec.tsx
+++ b/src/modules/lunch/meal/hook/meal.hook.spec.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useMeal } from "@/modules/lunch/meal/hook/meal.hook";
+import {
+    createOrder,
+    createMenuItem,
+} from "@/modules/lunch/__testhelpers__/model-builders";
+
+const TEN_SECONDS_IN_MILLISECONDS = 10000;
+describe("UseMeal", () => {
+    it("should resolve first variant as active variant", async () => {
+        // given
+        const diet = "Vegansk";
+
+        const menuItem = createMenuItem("Varmt", diet);
+        const orders = [createOrder("Varmt", "PROCURED", diet)];
+
+        // when
+        const { result } = renderHook(() =>
+            useMeal([
+                {
+                    menuItem,
+                    orders,
+                },
+            ]),
+        );
+
+        // then
+        await waitFor(() => {
+            expect(result.current.activeVariant).toEqual(0);
+        });
+    });
+
+    it(`should loop through variants with ${TEN_SECONDS_IN_MILLISECONDS}ms interval when multiple variants`, async () => {
+        // given
+        const meal1 = {
+            menuItem: createMenuItem("Varmt", "Vegansk"),
+            orders: [createOrder("Varmt", "PROCURED", "Vegansk")],
+        };
+        const meal2 = {
+            menuItem: createMenuItem("Varmt", "Vanlig"),
+            orders: [createOrder("Varmt", "PROCURED", "Vanlig")],
+        };
+
+        jest.useFakeTimers();
+
+        // when
+        const { result } = renderHook(() => useMeal([meal1, meal2]));
+
+        act(() => {
+            jest.advanceTimersByTime(TEN_SECONDS_IN_MILLISECONDS);
+        });
+
+        // when
+        await waitFor(() => {
+            expect(result.current.activeVariant).toEqual(1);
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(TEN_SECONDS_IN_MILLISECONDS);
+        });
+
+        // then
+        await waitFor(() => {
+            expect(result.current.activeVariant).toEqual(0);
+        });
+    });
+
+    it("should resolve hasOrders to true when there are orders", async () => {
+        // given
+        const variants = [
+            {
+                menuItem: createMenuItem("Varmt", "Vegansk"),
+                orders: [createOrder("Varmt", "PROCURED", "Vegansk")],
+            },
+        ];
+
+        // when
+        const { result } = renderHook(() => useMeal(variants));
+
+        // then
+        await waitFor(() => {
+            expect(result.current.hasOrders).toBeTruthy();
+        });
+    });
+
+    it("should resolve hasOrders to false when there are no orders", async () => {
+        // given
+        const variants = [
+            {
+                menuItem: createMenuItem("Varmt", "Vegansk"),
+                orders: [],
+            },
+        ];
+
+        // when
+        const { result } = renderHook(() => useMeal(variants));
+
+        // then
+        await waitFor(() => {
+            expect(result.current.hasOrders).toBeFalsy();
+        });
+    });
+});
+
+export {};

--- a/src/modules/lunch/meal/hook/meal.hook.ts
+++ b/src/modules/lunch/meal/hook/meal.hook.ts
@@ -1,0 +1,32 @@
+import { MealVariant } from "@/modules/lunch/lunch-module.hook";
+import { useEffect, useMemo, useState } from "react";
+
+const TEN_SECONDS_IN_MILLISECONDS = 10000;
+const MEAL_VARIANT_CAROUSEL_INTERVAL = TEN_SECONDS_IN_MILLISECONDS;
+
+type UseMeal = {
+    activeVariant: number;
+    hasOrders: boolean;
+};
+
+export const useMeal = (variants: MealVariant[]): UseMeal => {
+    const [activeVariant, setActiveVariant] = useState(0);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setActiveVariant((activeVariant + 1) % variants.length);
+        }, MEAL_VARIANT_CAROUSEL_INTERVAL);
+
+        return () => clearInterval(interval);
+    }, [activeVariant, variants.length]);
+
+    const hasOrders = useMemo(
+        () => variants[activeVariant].orders.length > 0,
+        [activeVariant, variants],
+    );
+
+    return {
+        activeVariant,
+        hasOrders,
+    };
+};

--- a/src/modules/lunch/meal/meal.spec.tsx
+++ b/src/modules/lunch/meal/meal.spec.tsx
@@ -1,0 +1,160 @@
+import Meal from "@/modules/lunch/meal/meal";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { formatDate } from "@/commons/helpers/datetime/datetime";
+import { useMeal } from "@/modules/lunch/meal/hook/meal.hook";
+import {
+    createMenuItem,
+    createOrder,
+} from "@/modules/lunch/__testhelpers__/model-builders";
+
+jest.mock("./hook/meal.hook");
+const mockedUseMeal = useMeal as jest.MockedFunction<typeof useMeal>;
+
+describe("Meal", () => {
+    it("should render meal type", () => {
+        // given
+        const mealType = "Varmt";
+
+        mockedUseMeal.mockReturnValue({
+            activeVariant: 0,
+            hasOrders: false,
+        });
+
+        // when
+        const { getByText } = render(
+            <Meal
+                mealType={mealType}
+                variants={[
+                    {
+                        menuItem: createMenuItem("Varmt", "Vanlig"),
+                        orders: [createOrder("Varmt", "PROCURED")],
+                    },
+                ]}
+            />,
+        );
+
+        // then
+        expect(getByText(mealType)).toBeInTheDocument();
+    });
+
+    it("should render meal description of active variant", () => {
+        // given
+        const mealType = "Varmt";
+        const variants = [
+            {
+                menuItem: createMenuItem(
+                    "Varmt",
+                    "Vanlig",
+                    formatDate(new Date()),
+                    "Test description of regular variant",
+                ),
+                orders: [],
+            },
+            {
+                menuItem: createMenuItem(
+                    "Varmt",
+                    "Vegetar",
+                    formatDate(new Date()),
+                    "Test description of vegetarian variant",
+                ),
+                orders: [],
+            },
+        ];
+        const activeVariant = 1;
+
+        mockedUseMeal.mockReturnValue({
+            activeVariant,
+            hasOrders: true,
+        });
+
+        // when
+        const { getByText } = render(
+            <Meal mealType={mealType} variants={variants} />,
+        );
+
+        // then
+        expect(
+            getByText(variants[activeVariant].menuItem.description),
+        ).toBeInTheDocument();
+    });
+
+    it("should render first name of everybody who ordered the active variant", async () => {
+        // given
+        const mealType = "Varmt";
+
+        const orders = [
+            createOrder("Varmt", "PROCURED"),
+            createOrder("Varmt", "PROCURED"),
+        ];
+
+        const variants = [
+            {
+                menuItem: createMenuItem(
+                    "Varmt",
+                    "Vanlig",
+                    formatDate(new Date()),
+                    "Test description of regular variant",
+                ),
+                orders,
+            },
+        ];
+
+        mockedUseMeal.mockReturnValue({
+            activeVariant: 0,
+            hasOrders: true,
+        });
+
+        // when
+        const { getByText } = render(
+            <Meal mealType={mealType} variants={variants} />,
+        );
+
+        // then
+        await waitFor(() => {
+            expect(getByText(orders[0].firstName)).toBeInTheDocument();
+            expect(getByText(orders[1].firstName)).toBeInTheDocument();
+        });
+    });
+
+    it("should render no orders message if no orders", () => {
+        // given
+        const mealType = "Varmt";
+        const variants = [
+            {
+                menuItem: createMenuItem(
+                    "Varmt",
+                    "Vanlig",
+                    formatDate(new Date()),
+                    "Test description of regular variant",
+                ),
+                orders: [],
+            },
+            {
+                menuItem: createMenuItem(
+                    "Varmt",
+                    "Vegetar",
+                    formatDate(new Date()),
+                    "Test description of vegetarian variant",
+                ),
+                orders: [],
+            },
+        ];
+        const activeVariant = 1;
+
+        mockedUseMeal.mockReturnValue({
+            activeVariant,
+            hasOrders: false,
+        });
+
+        // when
+        const { getByText } = render(
+            <Meal mealType={mealType} variants={variants} />,
+        );
+
+        // then
+        expect(getByText("Ingen bestillinger")).toBeInTheDocument();
+    });
+});
+
+export {};

--- a/src/modules/lunch/meal/meal.tsx
+++ b/src/modules/lunch/meal/meal.tsx
@@ -1,0 +1,40 @@
+import { Order } from "@/modules/lunch/api-client/types";
+import { MealVariant } from "@/modules/lunch/lunch-module.hook";
+import { useMeal } from "@/modules/lunch/meal/hook/meal.hook";
+import { Chip } from "@nextui-org/chip";
+
+const Meal = ({
+    mealType,
+    variants,
+}: {
+    mealType: Order["mealType"];
+    variants: MealVariant[];
+}) => {
+    const { activeVariant, hasOrders } = useMeal(variants);
+
+    return (
+        <div className="row-span-2 grid h-full grid-rows-[inherit] gap-y-[inherit] @container">
+            <div className="flex flex-col gap-y-2">
+                <h2 className="font-serif text-lg">{mealType}</h2>
+                <p className="text-sm text-gray-400 @xs:text-base">
+                    {variants[activeVariant].menuItem.description}
+                </p>
+            </div>
+            {hasOrders ? (
+                <ul className="flex h-max flex-wrap gap-2">
+                    {variants[activeVariant].orders.map((order) => (
+                        <li key={order.firstName}>
+                            <Chip variant="shadow" size="sm" color="secondary">
+                                {order.firstName}
+                            </Chip>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p>Ingen bestillinger</p>
+            )}
+        </div>
+    );
+};
+
+export default Meal;


### PR DESCRIPTION
Added meal description to each meal type for the lunch module. If there are orders for both the regular and vegan option, the description will rotate between them

fix #0046